### PR TITLE
feat: add TrainingPeaks PWX export

### DIFF
--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -1,6 +1,6 @@
-use crate::models::{Workout, AthleteProfile};
-use crate::pmc::{PmcMetrics, PmcCalculator};
-use chrono::{NaiveDate, Datelike};
+use crate::models::{AthleteProfile, Workout};
+use crate::pmc::{PmcCalculator, PmcMetrics};
+use chrono::{Datelike, NaiveDate};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -10,6 +10,7 @@ use thiserror::Error;
 pub mod csv;
 pub mod json;
 pub mod ml;
+pub mod pwx;
 pub mod text;
 
 /// Export format types
@@ -20,6 +21,7 @@ pub enum ExportFormat {
     Text,
     Html,
     Pdf,
+    Pwx,
 }
 
 impl ExportFormat {
@@ -30,6 +32,7 @@ impl ExportFormat {
             "text" | "txt" => Ok(ExportFormat::Text),
             "html" => Ok(ExportFormat::Html),
             "pdf" => Ok(ExportFormat::Pdf),
+            "pwx" | "wko5" | "trainingpeaks" => Ok(ExportFormat::Pwx),
             _ => Err(ExportError::UnsupportedFormat(s.to_string())),
         }
     }
@@ -246,12 +249,35 @@ impl ExportManager {
                 csv::export_pmc_data(&pmc_data, output_path)
             }
             (ExportFormat::Json, ExportType::TrainingReport) => {
-                let report = self.generate_training_report(&filtered_workouts, athlete_profile, &options.date_range)?;
+                let report = self.generate_training_report(
+                    &filtered_workouts,
+                    athlete_profile,
+                    &options.date_range,
+                )?;
                 json::export_training_report(&report, output_path)
             }
             (ExportFormat::Text, ExportType::TrainingReport) => {
-                let report = self.generate_training_report(&filtered_workouts, athlete_profile, &options.date_range)?;
+                let report = self.generate_training_report(
+                    &filtered_workouts,
+                    athlete_profile,
+                    &options.date_range,
+                )?;
                 text::export_training_report(&report, output_path)
+            }
+            (ExportFormat::Pwx, ExportType::TrainingPeaksFormat) => {
+                let output = output_path.as_ref();
+                if filtered_workouts.is_empty() {
+                    return Err(ExportError::InsufficientData(
+                        "PWX export requires at least one workout".to_string(),
+                    ));
+                }
+                if filtered_workouts.len() > 1 {
+                    return Err(ExportError::ConfigurationError(
+                        "PWX export supports one workout per file".to_string(),
+                    ));
+                }
+
+                pwx::PwxExporter::export_workout(filtered_workouts[0], output)
             }
             _ => Err(ExportError::UnsupportedFormat(format!(
                 "{:?} format for {:?} export type not yet implemented",
@@ -269,15 +295,23 @@ impl ExportManager {
         let owned_workouts: Vec<Workout> = workouts.iter().map(|&w| w.clone()).collect();
         let daily_tss = self.pmc_calculator.aggregate_daily_tss(&owned_workouts);
 
-        let start_date = _date_range.start.or_else(|| {
-            workouts.iter().map(|w| w.date).min()
-        }).ok_or(ExportError::InsufficientData("No workouts to analyze".to_string()))?;
+        let start_date = _date_range
+            .start
+            .or_else(|| workouts.iter().map(|w| w.date).min())
+            .ok_or(ExportError::InsufficientData(
+                "No workouts to analyze".to_string(),
+            ))?;
 
-        let end_date = _date_range.end.or_else(|| {
-            workouts.iter().map(|w| w.date).max()
-        }).ok_or(ExportError::InsufficientData("No workouts to analyze".to_string()))?;
+        let end_date = _date_range
+            .end
+            .or_else(|| workouts.iter().map(|w| w.date).max())
+            .ok_or(ExportError::InsufficientData(
+                "No workouts to analyze".to_string(),
+            ))?;
 
-        let pmc_series = self.pmc_calculator.calculate_pmc_series(&daily_tss, start_date, end_date)?;
+        let pmc_series = self
+            .pmc_calculator
+            .calculate_pmc_series(&daily_tss, start_date, end_date)?;
         Ok(pmc_series)
     }
 
@@ -331,14 +365,13 @@ impl ExportManager {
         _date_range: &DateRange,
     ) -> Result<TrainingReportSummary, ExportError> {
         if workouts.is_empty() {
-            return Err(ExportError::InsufficientData("No workouts to analyze".to_string()));
+            return Err(ExportError::InsufficientData(
+                "No workouts to analyze".to_string(),
+            ));
         }
 
         let total_workouts = workouts.len() as u16;
-        let total_tss: Decimal = workouts
-            .iter()
-            .filter_map(|w| w.summary.tss)
-            .sum();
+        let total_tss: Decimal = workouts.iter().filter_map(|w| w.summary.tss).sum();
 
         let total_duration_hours: Decimal = workouts
             .iter()
@@ -354,7 +387,9 @@ impl ExportManager {
         // Find most frequent sport
         let mut sport_counts = BTreeMap::new();
         for workout in workouts {
-            *sport_counts.entry(format!("{:?}", workout.sport)).or_insert(0) += 1;
+            *sport_counts
+                .entry(format!("{:?}", workout.sport))
+                .or_insert(0) += 1;
         }
 
         let most_frequent_sport = sport_counts
@@ -368,8 +403,13 @@ impl ExportManager {
         let last_date = workouts.iter().map(|w| w.date).max().unwrap();
         let date_range_days = (last_date - first_date).num_days() as u16 + 1;
 
-        let training_days = workouts.iter().map(|w| w.date).collect::<std::collections::HashSet<_>>().len();
-        let training_consistency = Decimal::from(training_days) / Decimal::from(date_range_days) * Decimal::from(100);
+        let training_days = workouts
+            .iter()
+            .map(|w| w.date)
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        let training_consistency =
+            Decimal::from(training_days) / Decimal::from(date_range_days) * Decimal::from(100);
 
         Ok(TrainingReportSummary {
             total_workouts,
@@ -383,7 +423,10 @@ impl ExportManager {
     }
 
     /// Generate weekly training summaries
-    fn generate_weekly_summaries(&self, workouts: &[&Workout]) -> Result<Vec<WeeklySummary>, ExportError> {
+    fn generate_weekly_summaries(
+        &self,
+        workouts: &[&Workout],
+    ) -> Result<Vec<WeeklySummary>, ExportError> {
         let mut weekly_summaries = Vec::new();
         let mut weekly_data: BTreeMap<(i32, u32), Vec<&Workout>> = BTreeMap::new();
 
@@ -391,13 +434,18 @@ impl ExportManager {
         for workout in workouts {
             let year = workout.date.year();
             let week = workout.date.iso_week().week();
-            weekly_data.entry((year, week)).or_insert_with(Vec::new).push(workout);
+            weekly_data
+                .entry((year, week))
+                .or_insert_with(Vec::new)
+                .push(workout);
         }
 
         // Generate summary for each week
         for ((year, week_num), week_workouts) in weekly_data {
-            let week_start = chrono::NaiveDate::from_isoywd_opt(year, week_num, chrono::Weekday::Mon).unwrap();
-            let week_end = chrono::NaiveDate::from_isoywd_opt(year, week_num, chrono::Weekday::Sun).unwrap();
+            let week_start =
+                chrono::NaiveDate::from_isoywd_opt(year, week_num, chrono::Weekday::Mon).unwrap();
+            let week_end =
+                chrono::NaiveDate::from_isoywd_opt(year, week_num, chrono::Weekday::Sun).unwrap();
 
             let total_tss: Decimal = week_workouts.iter().filter_map(|w| w.summary.tss).sum();
             let workout_count = week_workouts.len() as u16;
@@ -412,7 +460,11 @@ impl ExportManager {
                     .filter_map(|w| w.summary.total_distance)
                     .map(|d| d / Decimal::from(1000)) // Convert meters to km
                     .collect();
-                if distances.is_empty() { None } else { Some(distances.iter().sum()) }
+                if distances.is_empty() {
+                    None
+                } else {
+                    Some(distances.iter().sum())
+                }
             };
 
             let avg_daily_tss = total_tss / Decimal::from(7);
@@ -431,7 +483,8 @@ impl ExportManager {
 
                 entry.workout_count += 1;
                 entry.total_tss += workout.summary.tss.unwrap_or(Decimal::ZERO);
-                entry.total_duration_hours += Decimal::from(workout.duration_seconds) / Decimal::from(3600);
+                entry.total_duration_hours +=
+                    Decimal::from(workout.duration_seconds) / Decimal::from(3600);
             }
 
             weekly_summaries.push(WeeklySummary {
@@ -453,7 +506,10 @@ impl ExportManager {
     }
 
     /// Generate monthly training summaries
-    fn generate_monthly_summaries(&self, workouts: &[&Workout]) -> Result<Vec<MonthlySummary>, ExportError> {
+    fn generate_monthly_summaries(
+        &self,
+        workouts: &[&Workout],
+    ) -> Result<Vec<MonthlySummary>, ExportError> {
         let mut monthly_summaries = Vec::new();
         let mut monthly_data: BTreeMap<(i32, u32), Vec<&Workout>> = BTreeMap::new();
 
@@ -461,7 +517,10 @@ impl ExportManager {
         for workout in workouts {
             let year = workout.date.year();
             let month = workout.date.month();
-            monthly_data.entry((year, month)).or_insert_with(Vec::new).push(workout);
+            monthly_data
+                .entry((year, month))
+                .or_insert_with(Vec::new)
+                .push(workout);
         }
 
         let weekly_summaries = self.generate_weekly_summaries(workouts)?;
@@ -469,11 +528,21 @@ impl ExportManager {
         // Generate summary for each month
         for ((year, month_num), month_workouts) in monthly_data {
             let month_name = match month_num {
-                1 => "January", 2 => "February", 3 => "March", 4 => "April",
-                5 => "May", 6 => "June", 7 => "July", 8 => "August",
-                9 => "September", 10 => "October", 11 => "November", 12 => "December",
+                1 => "January",
+                2 => "February",
+                3 => "March",
+                4 => "April",
+                5 => "May",
+                6 => "June",
+                7 => "July",
+                8 => "August",
+                9 => "September",
+                10 => "October",
+                11 => "November",
+                12 => "December",
                 _ => "Unknown",
-            }.to_string();
+            }
+            .to_string();
 
             let total_tss: Decimal = month_workouts.iter().filter_map(|w| w.summary.tss).sum();
             let workout_count = month_workouts.len() as u16;
@@ -488,7 +557,11 @@ impl ExportManager {
                     .filter_map(|w| w.summary.total_distance)
                     .map(|d| d / Decimal::from(1000))
                     .collect();
-                if distances.is_empty() { None } else { Some(distances.iter().sum()) }
+                if distances.is_empty() {
+                    None
+                } else {
+                    Some(distances.iter().sum())
+                }
             };
 
             let days_in_month = chrono::NaiveDate::from_ymd_opt(year, month_num, 1)
@@ -515,7 +588,8 @@ impl ExportManager {
 
                 entry.workout_count += 1;
                 entry.total_tss += workout.summary.tss.unwrap_or(Decimal::ZERO);
-                entry.total_duration_hours += Decimal::from(workout.duration_seconds) / Decimal::from(3600);
+                entry.total_duration_hours +=
+                    Decimal::from(workout.duration_seconds) / Decimal::from(3600);
             }
 
             // Filter weekly summaries for this month
@@ -603,7 +677,10 @@ mod tests {
 
         let filtered = range.filter_workouts(&workouts);
         assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].date, NaiveDate::from_ymd_opt(2024, 9, 15).unwrap());
+        assert_eq!(
+            filtered[0].date,
+            NaiveDate::from_ymd_opt(2024, 9, 15).unwrap()
+        );
     }
 
     #[test]

--- a/src/export/pwx.rs
+++ b/src/export/pwx.rs
@@ -1,0 +1,420 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use chrono::{NaiveTime, Utc};
+use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::Writer;
+use rust_decimal::Decimal;
+
+use crate::models::{DataSource, Sport, Workout};
+use crate::power::MmpAnalyzer;
+
+use super::ExportError;
+
+const PWX_NAMESPACE: &str = "http://www.peaksware.com/PWX/1/0";
+
+impl From<quick_xml::Error> for ExportError {
+    fn from(err: quick_xml::Error) -> Self {
+        ExportError::SerializationError(err.to_string())
+    }
+}
+
+pub struct PwxExporter;
+
+impl PwxExporter {
+    pub fn export_workout(workout: &Workout, path: &Path) -> Result<(), ExportError> {
+        let xml = Self::generate_pwx_xml(workout)?;
+        fs::write(path, xml)?;
+        Ok(())
+    }
+
+    pub fn generate_pwx_xml(workout: &Workout) -> Result<String, ExportError> {
+        let mut writer = Writer::new_with_indent(Vec::new(), b' ', 2);
+
+        writer.write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))?;
+        writer.write_event(Event::Text(BytesText::new("\n")))?;
+
+        let mut pwx = BytesStart::new("pwx");
+        pwx.push_attribute(("version", "1.0"));
+        pwx.push_attribute(("xmlns", PWX_NAMESPACE));
+        writer.write_event(Event::Start(pwx))?;
+
+        Self::write_workout(&mut writer, workout)?;
+
+        writer.write_event(Event::End(BytesEnd::new("pwx")))?;
+
+        let bytes = writer.into_inner();
+        String::from_utf8(bytes).map_err(|err| ExportError::SerializationError(err.to_string()))
+    }
+
+    fn write_workout<W: Write>(
+        writer: &mut Writer<W>,
+        workout: &Workout,
+    ) -> Result<(), ExportError> {
+        writer.write_event(Event::Start(BytesStart::new("workout")))?;
+
+        Self::write_athlete(writer, workout)?;
+        Self::write_metadata(writer, workout)?;
+        Self::write_summary(writer, workout)?;
+        Self::write_segments(writer, workout)?;
+        Self::write_samples(writer, workout)?;
+        Self::write_power_curve(writer, workout)?;
+
+        if let Some(notes) = &workout.notes {
+            if !notes.trim().is_empty() {
+                Self::write_text_element(writer, "notes", notes)?;
+            }
+        }
+
+        writer.write_event(Event::End(BytesEnd::new("workout")))?;
+        Ok(())
+    }
+
+    fn write_athlete<W: Write>(
+        writer: &mut Writer<W>,
+        workout: &Workout,
+    ) -> Result<(), ExportError> {
+        writer.write_event(Event::Start(BytesStart::new("athlete")))?;
+        let name = workout.athlete_id.as_deref().unwrap_or("Unknown Athlete");
+        Self::write_text_element(writer, "name", name)?;
+        writer.write_event(Event::End(BytesEnd::new("athlete")))?;
+        Ok(())
+    }
+
+    fn write_metadata<W: Write>(
+        writer: &mut Writer<W>,
+        workout: &Workout,
+    ) -> Result<(), ExportError> {
+        let title = workout
+            .notes
+            .as_deref()
+            .filter(|s| !s.trim().is_empty())
+            .or(workout.source.as_deref())
+            .unwrap_or(workout.id.as_str());
+        Self::write_text_element(writer, "title", title)?;
+        Self::write_text_element(writer, "sportType", map_sport(&workout.sport))?;
+
+        let start_time = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
+        let datetime = chrono::NaiveDateTime::new(workout.date, start_time);
+        let time_iso =
+            chrono::DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc).to_rfc3339();
+        Self::write_text_element(writer, "time", &time_iso)?;
+
+        Self::write_text_element(writer, "duration", &workout.duration_seconds.to_string())?;
+        Self::write_text_element(writer, "durationType", "time")?;
+
+        if let Some(source) = &workout.source {
+            Self::write_text_element(writer, "device", source)?;
+        }
+
+        Self::write_text_element(writer, "dataSource", map_data_source(workout))?;
+        Ok(())
+    }
+
+    fn write_summary<W: Write>(
+        writer: &mut Writer<W>,
+        workout: &Workout,
+    ) -> Result<(), ExportError> {
+        writer.write_event(Event::Start(BytesStart::new("summary_data")))?;
+        Self::write_text_element(writer, "duration", &workout.duration_seconds.to_string())?;
+
+        if let Some(distance) = workout.summary.total_distance {
+            Self::write_text_element(writer, "distance", &decimal_to_string(distance))?;
+        }
+
+        if let Some(tss) = workout.summary.tss {
+            Self::write_text_element(writer, "tss", &decimal_to_string(tss))?;
+        }
+
+        if let Some(intensity_factor) = workout.summary.intensity_factor {
+            Self::write_text_element(
+                writer,
+                "intensityFactor",
+                &decimal_to_string(intensity_factor),
+            )?;
+        }
+
+        if let Some(normalized_power) = workout.summary.normalized_power {
+            Self::write_text_element(writer, "normalizedPower", &normalized_power.to_string())?;
+        }
+
+        if let Some(avg_power) = workout.summary.avg_power {
+            Self::write_text_element(writer, "avgPower", &avg_power.to_string())?;
+        }
+
+        if let Some(avg_hr) = workout.summary.avg_heart_rate {
+            Self::write_text_element(writer, "avgHeartRate", &avg_hr.to_string())?;
+        }
+
+        if let Some(calories) = workout.summary.calories {
+            Self::write_text_element(writer, "calories", &calories.to_string())?;
+        }
+
+        writer.write_event(Event::End(BytesEnd::new("summary_data")))?;
+        Ok(())
+    }
+
+    fn write_segments<W: Write>(
+        writer: &mut Writer<W>,
+        workout: &Workout,
+    ) -> Result<(), ExportError> {
+        let raw_data = match &workout.raw_data {
+            Some(data) if !data.is_empty() => data,
+            _ => return Ok(()),
+        };
+
+        let lap_numbers: BTreeSet<u16> = raw_data.iter().filter_map(|dp| dp.lap_number).collect();
+        if lap_numbers.is_empty() {
+            return Ok(());
+        }
+
+        writer.write_event(Event::Start(BytesStart::new("segments")))?;
+        for lap in lap_numbers {
+            writer.write_event(Event::Start(BytesStart::new("segment")))?;
+            Self::write_text_element(writer, "name", &format!("Lap {}", lap))?;
+            Self::write_text_element(writer, "type", "Lap")?;
+            writer.write_event(Event::End(BytesEnd::new("segment")))?;
+        }
+        writer.write_event(Event::End(BytesEnd::new("segments")))?;
+        Ok(())
+    }
+
+    fn write_samples<W: Write>(
+        writer: &mut Writer<W>,
+        workout: &Workout,
+    ) -> Result<(), ExportError> {
+        let raw_data = match &workout.raw_data {
+            Some(data) if !data.is_empty() => data,
+            _ => return Ok(()),
+        };
+
+        let max_samples = 10_000usize;
+        let len = raw_data.len();
+        let step = if len > max_samples {
+            (len / max_samples).max(1)
+        } else {
+            1
+        };
+
+        let mut indices: Vec<usize> = (0..len).step_by(step).collect();
+        if let Some(last_index) = len.checked_sub(1) {
+            if indices.last().copied() != Some(last_index) {
+                indices.push(last_index);
+            }
+        }
+
+        for idx in indices {
+            let dp = &raw_data[idx];
+            writer.write_event(Event::Start(BytesStart::new("sample")))?;
+            Self::write_text_element(writer, "timeoffset", &dp.timestamp.to_string())?;
+
+            if let Some(hr) = dp.heart_rate {
+                Self::write_text_element(writer, "hr", &hr.to_string())?;
+            }
+            if let Some(power) = dp.power {
+                Self::write_text_element(writer, "pwr", &power.to_string())?;
+            }
+            if let Some(cadence) = dp.cadence {
+                Self::write_text_element(writer, "cad", &cadence.to_string())?;
+            }
+            if let Some(speed) = dp.speed {
+                Self::write_text_element(writer, "spd", &decimal_to_string(speed))?;
+            }
+            if let Some(distance) = dp.distance {
+                Self::write_text_element(writer, "dist", &decimal_to_string(distance))?;
+            }
+            if let Some(elevation) = dp.elevation {
+                Self::write_text_element(writer, "alt", &elevation.to_string())?;
+            }
+            if let Some(left) = dp.left_power {
+                Self::write_text_element(writer, "leftBalance", &left.to_string())?;
+            }
+            if let Some(right) = dp.right_power {
+                Self::write_text_element(writer, "rightBalance", &right.to_string())?;
+            }
+
+            writer.write_event(Event::End(BytesEnd::new("sample")))?;
+        }
+
+        Ok(())
+    }
+
+    fn write_power_curve<W: Write>(
+        writer: &mut Writer<W>,
+        workout: &Workout,
+    ) -> Result<(), ExportError> {
+        let raw_data = match &workout.raw_data {
+            Some(data) if data.iter().any(|dp| dp.power.is_some()) => data,
+            _ => return Ok(()),
+        };
+
+        let curve = match MmpAnalyzer::calculate_mmp(raw_data) {
+            Ok(curve) => curve,
+            Err(_) => return Ok(()),
+        };
+
+        if curve.duration_seconds.is_empty() {
+            return Ok(());
+        }
+
+        writer.write_event(Event::Start(BytesStart::new("metrics")))?;
+        writer.write_event(Event::Start(BytesStart::new("powerCurve")))?;
+
+        let total = curve.duration_seconds.len();
+        let step = if total > 300 { (total / 300).max(1) } else { 1 };
+
+        let mut idx = 0;
+        while idx < total {
+            let duration = curve.duration_seconds[idx];
+            let power = curve.max_power[idx];
+            writer.write_event(Event::Start(BytesStart::new("peak")))?;
+            Self::write_text_element(writer, "seconds", &duration.to_string())?;
+            Self::write_text_element(writer, "watts", &power.to_string())?;
+            writer.write_event(Event::End(BytesEnd::new("peak")))?;
+            idx += step;
+        }
+
+        if (total - 1) % step != 0 {
+            let duration = *curve.duration_seconds.last().unwrap();
+            let power = *curve.max_power.last().unwrap();
+            writer.write_event(Event::Start(BytesStart::new("peak")))?;
+            Self::write_text_element(writer, "seconds", &duration.to_string())?;
+            Self::write_text_element(writer, "watts", &power.to_string())?;
+            writer.write_event(Event::End(BytesEnd::new("peak")))?;
+        }
+
+        writer.write_event(Event::End(BytesEnd::new("powerCurve")))?;
+        writer.write_event(Event::End(BytesEnd::new("metrics")))?;
+        Ok(())
+    }
+
+    fn write_text_element<W: Write>(
+        writer: &mut Writer<W>,
+        name: &str,
+        value: &str,
+    ) -> Result<(), ExportError> {
+        let start = BytesStart::new(name);
+        writer.write_event(Event::Start(start))?;
+        writer.write_event(Event::Text(BytesText::new(value)))?;
+        writer.write_event(Event::End(BytesEnd::new(name)))?;
+        Ok(())
+    }
+}
+
+fn map_sport(sport: &Sport) -> &'static str {
+    match sport {
+        Sport::Running => "Run",
+        Sport::Cycling => "Bike",
+        Sport::Swimming => "Swim",
+        Sport::Triathlon => "Tri",
+        Sport::Rowing => "Row",
+        Sport::CrossTraining => "Cross",
+    }
+}
+
+fn map_data_source(workout: &Workout) -> &'static str {
+    match workout.data_source {
+        DataSource::HeartRate => "HeartRate",
+        DataSource::Power => "Power",
+        DataSource::Pace => "Pace",
+        DataSource::Rpe => "RPE",
+    }
+}
+
+fn decimal_to_string(value: Decimal) -> String {
+    value.normalize().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{DataPoint, WorkoutSummary, WorkoutType};
+    use chrono::NaiveDate;
+    use rust_decimal_macros::dec;
+    use std::fs;
+    use tempfile::NamedTempFile;
+
+    fn sample_data_point(
+        timestamp: u32,
+        power: u16,
+        heart_rate: u16,
+        distance: Decimal,
+    ) -> DataPoint {
+        DataPoint {
+            timestamp,
+            heart_rate: Some(heart_rate),
+            power: Some(power),
+            pace: None,
+            elevation: Some(100),
+            cadence: Some(90),
+            speed: Some(dec!(8.5)),
+            distance: Some(distance),
+            left_power: None,
+            right_power: None,
+            ground_contact_time: None,
+            vertical_oscillation: None,
+            stride_length: None,
+            stroke_count: None,
+            stroke_type: None,
+            lap_number: Some(1),
+            sport_transition: None,
+        }
+    }
+
+    fn build_test_workout() -> Workout {
+        let raw_data = vec![
+            sample_data_point(0, 220, 145, dec!(0)),
+            sample_data_point(30, 230, 150, dec!(250)),
+            sample_data_point(60, 240, 152, dec!(500)),
+        ];
+
+        Workout {
+            id: "workout_20240930".to_string(),
+            date: NaiveDate::from_ymd_opt(2024, 9, 30).unwrap(),
+            sport: Sport::Cycling,
+            duration_seconds: 3600,
+            workout_type: WorkoutType::Endurance,
+            data_source: DataSource::Power,
+            raw_data: Some(raw_data),
+            summary: WorkoutSummary {
+                avg_heart_rate: Some(148),
+                max_heart_rate: Some(165),
+                avg_power: Some(215),
+                normalized_power: Some(230),
+                intensity_factor: Some(dec!(0.85)),
+                tss: Some(dec!(85.2)),
+                total_distance: Some(dec!(25000)),
+                calories: Some(780),
+                ..WorkoutSummary::default()
+            },
+            notes: Some("Morning ride".to_string()),
+            athlete_id: Some("athlete_a".to_string()),
+            source: Some("Garmin Edge".to_string()),
+        }
+    }
+
+    #[test]
+    fn generates_pwx_xml_with_expected_sections() {
+        let workout = build_test_workout();
+        let xml = PwxExporter::generate_pwx_xml(&workout).unwrap();
+
+        assert!(xml.contains("<pwx"));
+        assert!(xml.contains("<sportType>Bike</sportType>"));
+        assert!(xml.contains("<summary_data>"));
+        assert!(xml.contains("<sample>"));
+        assert!(xml.contains("<powerCurve>"));
+    }
+
+    #[test]
+    fn exports_pwx_file_to_disk() {
+        let workout = build_test_workout();
+        let file = NamedTempFile::new().unwrap();
+
+        PwxExporter::export_workout(&workout, file.path()).unwrap();
+
+        let content = fs::read_to_string(file.path()).unwrap();
+        assert!(content.contains("Morning ride"));
+    }
+}


### PR DESCRIPTION
## Summary
- add PWX exporter wiring and expose new format option
- generate TrainingPeaks/WKO5 PWX XML with samples and power curve data
- cover exporter with unit tests for XML output and disk export

## Testing
- cargo fmt
- cargo test --lib export::pwx::tests
- cargo clippy --lib