### PR TITLE
chore: update deprecated GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,19 +29,19 @@ jobs:
           override: true
 
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
@@ -79,7 +79,7 @@ jobs:
           fail-on-alert: true
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: benchmark-results
@@ -89,7 +89,7 @@ jobs:
 
       - name: Comment PR with benchmark results
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
Updated GitHub Actions dependencies to their latest stable versions:
- actions/cache: v3 → v4 (3 instances)
- actions/upload-artifact: v3 → v4
- actions/github-script: v6 → v7

These updates resolve deprecation warnings and provide improved performance and reliability for the benchmark CI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)